### PR TITLE
Fix for deprecated getMonolog method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Require the package in composer:
 
 ```javascript
 "require": {
-    "pod-point/laravel-monolog-kinesis": "^1.0"
+    "pod-point/laravel-monolog-kinesis": "^2.0"
 },
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,14 @@
     "type": "library",
     "require": {
         "php": ">=7.0",
-        "illuminate/support": "5.*",
+        "illuminate/support": "^5.6",
         "monolog/monolog": "~1.11",
         "aws/aws-sdk-php": "^3.62"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~7.0",
+        "orchestra/testbench": "~3.6"
     },
     "license": "MIT",
     "authors": [

--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -23,7 +23,7 @@ class ServiceProvider extends LaravelServiceProvider
         ]);
 
         if (config('kinesis.stream')) {
-            $monolog = Log::getMonolog();
+            $monolog = Log::getLogger();
 
             $config = [
                 'region' => config('kinesis.aws.region'),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
     //
 }

--- a/tests/unit/ServiceProviderTest.php
+++ b/tests/unit/ServiceProviderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use PodPoint\KinesisLogger\Providers\ServiceProvider;
+use Orchestra\Testbench\TestCase;
+use PodPoint\KinesisLogger\Monolog\KinesisHandler;
+
+class ServiceProviderTest extends TestCase
+{
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('kinesis.stream', 'stream');
+        $app['config']->set('kinesis.aws.region', 'region');
+        $app['config']->set('kinesis.aws.key', 'key');
+        $app['config']->set('kinesis.aws.secret', 'secret');
+        $app['config']->set('kinesis.level', 1);
+    }
+
+    /**
+     * Test the service provider registers the handler.
+     */
+    public function testServiceProvider()
+    {
+        $provider = new ServiceProvider($this->app);
+        $provider->boot();
+
+        $monolog = Log::getLogger();
+
+        $this->assertEquals(KinesisHandler::class, get_class($monolog->popHandler()));
+    }
+}


### PR DESCRIPTION
Major version release as this breaks compatibility with Laravel < 5.6