### PR TITLE
Allow custom http client options

### DIFF
--- a/src/Kinesis.php
+++ b/src/Kinesis.php
@@ -46,6 +46,7 @@ class Kinesis implements Client
         $config = [
             'region' => Arr::get($channelConfig, 'region', Arr::get($defaultConfig, 'region')),
             'version' => Arr::get($channelConfig, 'version', Arr::get($defaultConfig, 'version', 'latest')),
+            'http' => Arr::get($channelConfig, 'http', Arr::get($defaultConfig, 'http', [])),
         ];
 
         if (Arr::has($channelConfig, ['key', 'secret'])) {

--- a/tests/MonologKinesisTest.php
+++ b/tests/MonologKinesisTest.php
@@ -112,4 +112,28 @@ class MonologKinesisTest extends TestCase
 
         logger()->warning('Something went wrong.');
     }
+
+    public function test_channel_specific_http_client_options_can_be_given()
+    {
+        $this->mockKinesisWith(function ($mock) {
+            $mock->shouldReceive('configure')->once()->with(m::on(function ($argument) {
+                return $argument['http'] === ['verify' => false];
+            }))->andReturn($mock);
+
+            $mock->shouldReceive('putRecord')->once();
+        });
+
+        config()->set('logging.default', 'another_channel');
+        config()->set('logging.channels.another_channel', [
+            'driver' => 'kinesis',
+            'region' => 'another_region',
+            'stream' => 'logging',
+            'level' => 'debug',
+            'http' => [
+                'verify' => false,
+            ],
+        ]);
+
+        logger()->warning('Something went wrong.');
+    }
 }


### PR DESCRIPTION
It is often necessary to customize the Kinesis client options, so it is important to have this configuration